### PR TITLE
( feat ): start round implemented

### DIFF
--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -4,6 +4,7 @@ import './App.css'
 import CommandBar from 'src/components/CommandBar'
 import GameInput from 'src/components/GameInput'
 import SaladBowl from 'src/components/SaladBowl'
+import Rounds from 'src/components/Rounds'
 
 type Game = string
 type Entry = string
@@ -15,6 +16,7 @@ interface AppProps {
 interface AppState {
   games: Game[]
   entries: Entry[]
+  roundStarted: boolean
 }
 
 export default class App extends React.Component<AppProps, AppState> {
@@ -23,7 +25,12 @@ export default class App extends React.Component<AppProps, AppState> {
   // }
   state = {
     games: [] as Game[],
-    entries: [] as Entry[]
+    entries: [] as Entry[],
+    roundStarted: false as boolean
+  }
+
+  startRound = () => {
+    this.setState({ roundStarted: true })
   }
 
   onCreateNewGame = () => {
@@ -58,6 +65,10 @@ export default class App extends React.Component<AppProps, AppState> {
         <div className="App-body">
           <GameInput updateGameEntries={this.updateGameEntries} />
           <SaladBowl entries={this.state.entries} />
+          <Rounds
+            hasMinEntryCount={this.state.entries.length > 3}
+            startRound={this.startRound}
+          />
         </div>
       </div>
     )

--- a/src/components/Rounds/index.tsx
+++ b/src/components/Rounds/index.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react'
+
+interface RoundsProps {
+  startRound: () => void
+  hasMinEntryCount: boolean
+}
+interface RoundsState {
+  currentRound: number
+}
+
+export default class Rounds extends React.Component<RoundsProps, RoundsState> {
+  // STYLE Rounds for active states
+  state = {
+    currentRound: 0
+  }
+
+  handleClick = () => {
+    this.setState(({ currentRound }) => {
+      return { currentRound: currentRound + 1 <= 3 ? currentRound + 1 : 1 }
+    }, this.props.startRound)
+  }
+
+  render() {
+    const styleProps = {
+      border: '2px solid grey',
+      padding: '0px 5px',
+      margin: '0px 5px'
+    }
+
+    console.log('hasMinCount:', this.props.hasMinEntryCount)
+
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'center',
+          padding: '10px 20px'
+        }}
+      >
+        <button
+          disabled={!this.props.hasMinEntryCount}
+          style={{ margin: '0px 5px' }}
+          onClick={this.handleClick}
+        >
+          Start Round
+        </button>
+        <div
+          style={{
+            ...styleProps,
+            background: this.state.currentRound === 1 ? 'red' : 'transparent'
+          }}
+        >
+          1
+        </div>
+        <div
+          style={{
+            ...styleProps,
+            background: this.state.currentRound === 2 ? 'red' : 'transparent'
+          }}
+        >
+          2
+        </div>
+        <div
+          style={{
+            ...styleProps,
+            background: this.state.currentRound === 3 ? 'red' : 'transparent'
+          }}
+        >
+          3
+        </div>
+      </div>
+    )
+  }
+}


### PR DESCRIPTION
todo: 

- [x] start rounds
- [x] display selected round

Next task: 
* implement "salad bowl" "skipped" "guessed" buckets 
* Add mechanism for adding to skipped and guessed